### PR TITLE
Python 3.11 support: use collections.abc instead of collections

### DIFF
--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -12,7 +12,7 @@ import re
 import datetime
 import urllib.request, urllib.error, urllib.parse
 import html
-from collections import Iterable
+from collections.abc import Iterable
 from .options import BaseOptions, ChartOptions, ColorAxisOptions, \
     ColorsOptions, CreditsOptions, DrilldownOptions, ExportingOptions, \
     GlobalOptions, LabelsOptions, LangOptions, \

--- a/highcharts/highmaps/highmaps.py
+++ b/highcharts/highmaps/highmaps.py
@@ -13,7 +13,7 @@ import json, uuid
 import re
 import datetime
 import html
-from collections import Iterable
+from collections.abc import Iterable
 from .options import BaseOptions, ChartOptions, \
     ColorsOptions, ColorAxisOptions, CreditsOptions, DrilldownOptions, ExportingOptions, \
     GlobalOptions, LabelsOptions, LangOptions, \

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -10,7 +10,7 @@ import json, uuid
 import re
 import datetime
 import html
-from collections import Iterable
+from collections.abc import Iterable
 from .options import BaseOptions, ChartOptions, \
     ColorsOptions, CreditsOptions, ExportingOptions, \
     GlobalOptions, LabelsOptions, LangOptions, \


### PR DESCRIPTION
As of Python 3.10 `collections` Abstract Base Classes are no longer available from the `collections` module and have to be imported from `collections.abc` instead.